### PR TITLE
Add elder companion scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ There are two main patterns demonstrated:
 - Start the server with `npm run dev`
 - Open your browser to [http://localhost:3000](http://localhost:3000). It should default to the `chatSupervisor` Agent Config.
 - You can change examples via the "Scenario" dropdown in the top right.
+- A new `elderCompanion` scenario is included as a minimal conversational companion for older adults.
 
 # Agentic Pattern 1: Chat-Supervisor
 

--- a/src/app/agentConfigs/elderCompanion.ts
+++ b/src/app/agentConfigs/elderCompanion.ts
@@ -1,0 +1,20 @@
+import { RealtimeAgent } from '@openai/agents/realtime';
+
+export const elderCompanionAgent = new RealtimeAgent({
+  name: 'elderCompanion',
+  voice: 'nova',
+  instructions: `
+You are a friendly and patient conversational companion designed to talk with older adults.
+Your goal is to help reduce loneliness and gently stimulate cognition through engaging conversation.
+
+- Keep your responses short, positive and easy to understand.
+- Encourage the user to share memories and stories from their life.
+- When they mention hobbies or interests, ask follow-up questions.
+- If the user has trouble recalling something, offer gentle prompts and do not correct them harshly.
+- Avoid giving medical or therapeutic advice. Suggest consulting a professional if they request it.
+`,
+  tools: [],
+  handoffs: [],
+});
+
+export const elderCompanionScenario = [elderCompanionAgent];

--- a/src/app/agentConfigs/index.ts
+++ b/src/app/agentConfigs/index.ts
@@ -1,6 +1,7 @@
 import { simpleHandoffScenario } from './simpleHandoff';
 import { customerServiceRetailScenario } from './customerServiceRetail';
 import { chatSupervisorScenario } from './chatSupervisor';
+import { elderCompanionScenario } from './elderCompanion';
 
 import type { RealtimeAgent } from '@openai/agents/realtime';
 
@@ -9,6 +10,7 @@ export const allAgentSets: Record<string, RealtimeAgent[]> = {
   simpleHandoff: simpleHandoffScenario,
   customerServiceRetail: customerServiceRetailScenario,
   chatSupervisor: chatSupervisorScenario,
+  elderCompanion: elderCompanionScenario,
 };
 
 export const defaultAgentSetKey = 'chatSupervisor';


### PR DESCRIPTION
## Summary
- provide a new `elderCompanion` agent config for a basic conversational partner for older adults
- expose the new scenario through the agent set index
- document the scenario in the README

## Testing
- `npm run lint` *(fails: eventNameSuffix unused, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684777290764832aa577f65fe4a5b9a3